### PR TITLE
Before and After Deploy Hooks, Stability Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,12 @@ Path on your local for the files you want to be deployed to the remote server. N
 Type: `String`
 Default value: `'current'`
 
-Password for the username on the remote server.
+Path to direcotry to symlink with most recent release.
+
+#### options.before_deploy, options.after_deploy
+Type: `String`
+
+Commands to run on the server before and after deploy directory is created and symlinked. 
 
 ### Usage Examples
 
@@ -111,6 +116,23 @@ grunt.initConfig({
           }
       }
   }
+});
+```
+
+### Before and After Hooks
+```js
+grunt.initConfig({
+  environments: {
+    production: {
+      host: '123.45.67.89',
+      username: 'root',
+      password: 'password',
+      deploy_path: '/sites/great_project',
+      local_path: '.',
+      before_deploy: 'cd /sites/great_project/releases/current && forever stopall',
+      after_deploy: 'cd /sites/great_project/releases/current && npm install && forever start app.js'
+    }
+  },
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   ],
   "dependencies": {
     "async": "^0.8.0",
+    "extend": "^1.3.0",
     "moment": "^2.6.0",
     "ssh2": "^0.2.22"
   }


### PR DESCRIPTION
This request adds:
    - The options `before_deploy` and `after_deploy`  allow user to run arbitrary commands before and after the release is added and symlinked. These are supported by methods `onBeforeDeploy` and `onAfterDeploy`. Example for this new behavior has been added to readme.
    - Dependency on `extend` module to merge default options with user options. Values listed as defaults in docs were not previously being applied.
    - Refactor of release directory creation command to allow first release to create the `releases` directory.
