### PR TITLE
Options for zipping the upload and keeping a specified number of releases.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,11 @@ Type: `String`
 Commands to run on the server before and after deploy directory is created and symlinked. 
 
 #### options.releases_to_keep
-Type: `String`
+Type: `Number`
+
+#### options.zip_deploy
+Type: `Boolean`
+Default value: `true`
 
 The number of builds (including the current build) to keep in the remote releases directory. Must be >= 1.
 

--- a/README.md
+++ b/README.md
@@ -96,11 +96,11 @@ Commands to run on the server before and after deploy directory is created and s
 #### options.releases_to_keep
 Type: `Number`
 
+The number of builds (including the current build) to keep in the remote releases directory. Must be >= 1.
+
 #### options.zip_deploy
 Type: `Boolean`
-Default value: `true`
-
-The number of builds (including the current build) to keep in the remote releases directory. Must be >= 1.
+Default value: `false`
 
 ### Usage Examples
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# grunt-ssh-deploy (Version: 0.2.2)
+# grunt-ssh-deploy (Version: 0.2.4)
 
 > SSH Deployment for Grunt using [ssh2](https://github.com/mscdex/ssh2).
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ Type: `String`
 
 Commands to run on the server before and after deploy directory is created and symlinked. 
 
+#### options.releases_to_keep
+Type: `String`
+
+The number of builds (including the current build) to keep in the remote releases directory. Must be >= 1.
+
 ### Usage Examples
 
 #### Custom Options
@@ -111,7 +116,8 @@ grunt.initConfig({
               deploy_path: '/full/path',
               local_path: 'dist',
               current_symlink: 'current',
-              debug: true
+              debug: true,
+              number_of_releases: '3'
           }
       },
       production: {
@@ -122,7 +128,8 @@ grunt.initConfig({
               port: '<%= secret.production.port %>',
               deploy_path: '/full/path',
               local_path: 'dist',
-              current_symlink: 'current'
+              current_symlink: 'current',
+              number_of_releases: '5'
           }
       }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-ssh-deploy",
   "description": "Grunt SSH deployment",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "homepage": "https://github.com/dasuchin/grunt-ssh-deploy",
   "author": {
     "name": "Dustin Carlson",

--- a/tasks/ssh_deploy.js
+++ b/tasks/ssh_deploy.js
@@ -1,10 +1,10 @@
 /*
-* grunt-ssh-deploy
-* https://github.com/dcarlson/grunt-ssh-deploy
-*
-* Copyright (c) 2014 Dustin Carlson
-* Licensed under the MIT license.
-*/
+ * grunt-ssh-deploy
+ * https://github.com/dcarlson/grunt-ssh-deploy
+ *
+ * Copyright (c) 2014 Dustin Carlson
+ * Licensed under the MIT license.
+ */
 
 'use strict';
 
@@ -15,14 +15,14 @@ var getScpOptions = function(options) {
         username: options.username
     };
 
-    if(options.privateKey) {
+    if (options.privateKey) {
         scpOptions.privateKey = options.privateKey;
     }
     else if (options.password) {
         scpOptions.password = options.password;
     }
     else if (options.agent) {
-        //ssh-agent will be used
+        scpOptions.agent = options.agent;
     } else {
         throw new Error('Agent, Password or private key required for secure copy.');
     }
@@ -115,7 +115,7 @@ module.exports = function(grunt) {
             };
 
             var zipForDeploy = function(callback) {
-                if (!options.zip_deploy) callback();
+                if (!options.zip_deploy) return callback();
                 var command = "tar -czvf ./deploy.tgz --directory=" + options.local_path + " . --exclude=deploy.tgz";
                 grunt.log.subhead('--------------- ZIPPING FOLDER');
                 grunt.log.subhead('--- ' + command);
@@ -123,11 +123,11 @@ module.exports = function(grunt) {
             };
 
             var onBeforeDeploy = function(callback){
-                if (typeof options.before_deploy === "undefined") callback();
+                if (typeof options.before_deploy === "undefined") return callback();
                 var command = options.before_deploy;
                 grunt.log.subhead("--------------- RUNNING PRE-DEPLOY COMMANDS");
                 if (command instanceof Array) {
-                    async.eachSeries(command, function (command, callback) {
+                    async.eachSeries(command, function(command, callback) {
                         grunt.log.subhead('--- ' + command);
                         execRemote(command, options.debug, callback);
                     }, callback);
@@ -162,7 +162,7 @@ module.exports = function(grunt) {
             };
 
             var unzipOnRemote = function(callback) {
-                if (!options.zip_deploy) callback();
+                if (!options.zip_deploy) return callback();
                 var goToCurrent = "cd " + options.deploy_path + "/releases/" + timestamp;
                 var untar = "tar -xzvf deploy.tgz";
                 var cleanup = "rm " + options.deploy_path + "/releases/" + timestamp + "/deploy.tgz";
@@ -189,11 +189,11 @@ module.exports = function(grunt) {
             };
 
             var onAfterDeploy = function(callback){
-                if (typeof options.after_deploy === "undefined") callback();
+                if (typeof options.after_deploy === "undefined") return callback();
                 var command = options.after_deploy;
                 grunt.log.subhead("--------------- RUNNING POST-DEPLOY COMMANDS");
                 if (command instanceof Array) {
-                    async.eachSeries(command, function (command, callback) {
+                    async.eachSeries(command, function(command, callback) {
                         grunt.log.subhead('--- ' + command);
                         execRemote(command, options.debug, callback);
                     }, callback);
@@ -204,7 +204,7 @@ module.exports = function(grunt) {
             };
 
             var remoteCleanup = function(callback) {
-                if (typeof options.number_of_releases === 'undefined') callback();
+                if (typeof options.number_of_releases === 'undefined') return callback();
                 if (options.number_of_releases < 1) options.number_of_releases = 1;
 
                 var command = "rm -rf `ls -r " + options.deploy_path + "/releases/ | awk 'NR>" + options.number_of_releases + "'`";
@@ -214,7 +214,7 @@ module.exports = function(grunt) {
             };
 
             var deleteZip = function(callback) {
-                if (!options.zip_deploy) callback();
+                if (!options.zip_deploy) return callback();
                 var command = 'rm deploy.tgz';
                 grunt.log.subhead('--------------- LOCAL CLEANUP');
                 grunt.log.subhead('--- ' + command);

--- a/tasks/ssh_deploy.js
+++ b/tasks/ssh_deploy.js
@@ -204,6 +204,16 @@ module.exports = function(grunt) {
                 }
             };
 
+            var remoteCleanup = function(callback) {
+                if (typeof options.number_of_releases !== 'number') callback();
+                if (options.number_of_releases < 1) options.number_of_releases = 1;
+
+                var command = "rm -rf `ls -t " + options.deploy_path + " | awk 'NR>" + options.number_of_releases + "'`";
+                grunt.log.subhead('--------------- REMOVING OLD BUILDS');
+                grunt.log.subhead('--- ' + command);
+                execRemote(command, options.debug, callback);
+            };
+
             var localCleanup = function(callback) {
                 var command = 'rm deploy.tgz';
                 grunt.log.subhead('--------------- LOCAL CLEANUP');
@@ -226,6 +236,7 @@ module.exports = function(grunt) {
                 unzipOnRemote,
                 updateSymlink,
                 onAfterDeploy,
+                remoteCleanup,
                 localCleanup,
                 closeConnection
             ], function () {

--- a/tasks/ssh_deploy.js
+++ b/tasks/ssh_deploy.js
@@ -44,7 +44,7 @@ module.exports = function(grunt) {
         var defaults = {
             current_symlink: 'current',
             port: 22,
-            zip_deploy: true
+            zip_deploy: false
         };
 
         var options = extend({}, defaults, grunt.config.get('environments').options,
@@ -207,7 +207,7 @@ module.exports = function(grunt) {
                 if (typeof options.number_of_releases !== 'number') callback();
                 if (options.number_of_releases < 1) options.number_of_releases = 1;
 
-                var command = "rm -rf `ls -t " + options.deploy_path + " | awk 'NR>" + options.number_of_releases + "'`";
+                var command = "rm -rf `ls -r " + options.deploy_path + " | awk 'NR>" + options.number_of_releases + "'`";
                 grunt.log.subhead('--------------- REMOVING OLD BUILDS');
                 grunt.log.subhead('--- ' + command);
                 execRemote(command, options.debug, callback);


### PR DESCRIPTION
scp was being extra slow on production deploys to remote servers so I started zipping the build directory before the scp call and unzipping after. I made this an option which defaults to true.

There has been talk in issues about having an option for cleaning up the release directory by only keeping a certain number of build directories around. I made an option for this.