### PR TITLE
Added option max_buffer to specify the maximum amount of data on stdout and stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ Default value: `false`
 
 Compress the build before uploading.
 
+#### options.max_buffer
+Type: `Number`
+Default value: `200 * 1024`
+
+Largest amount of data allowed on stdout or stderr.
+
 ### Usage Examples
 
 #### Custom Options

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-ssh-deploy",
   "description": "Grunt SSH deployment",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "homepage": "https://github.com/dasuchin/grunt-ssh-deploy",
   "author": {
     "name": "Dustin Carlson",

--- a/tasks/ssh_deploy.js
+++ b/tasks/ssh_deploy.js
@@ -44,7 +44,8 @@ module.exports = function(grunt) {
         var defaults = {
             current_symlink: 'current',
             port: 22,
-            zip_deploy: false
+            zip_deploy: false,
+            max_buffer: 200 * 1024
         };
 
         var options = extend({}, defaults, grunt.config.get('environments').options,
@@ -78,7 +79,11 @@ module.exports = function(grunt) {
             var childProcessExec = require('child_process').exec;
 
             var execLocal = function(cmd, next) {
-                childProcessExec(cmd, function(err, stdout, stderr){
+            	var execOptions = {
+            		maxBuffer: options.max_buffer	
+            	};
+            	
+                childProcessExec(cmd, execOptions, function(err, stdout, stderr){
                     grunt.log.debug(cmd);
                     grunt.log.debug('stdout: ' + stdout);
                     grunt.log.debug('stderr: ' + stderr);


### PR DESCRIPTION
Fix for #19 

I added an option max_buffer which will be given to `childProcessExec`. This allows to set the `zip_deploy` option on bigger deploy jobs too.