### PR TITLE
Fix archive removal.

### DIFF
--- a/tasks/ssh_deploy.js
+++ b/tasks/ssh_deploy.js
@@ -170,8 +170,7 @@ module.exports = function(grunt) {
                 if (!options.zip_deploy) return callback();
                 var goToCurrent = "cd " + options.deploy_path + "/releases/" + timestamp;
                 var untar = "tar -xzvf deploy.tgz";
-                var cleanup = "rm " + options.deploy_path + "/releases/" + timestamp + "/deploy.tgz";
-                var command = goToCurrent + " && " + untar + " && " + cleanup;
+                var command = goToCurrent + " && " + untar + " && rm deploy.tgz";
                 grunt.log.subhead('--------------- UNZIP ZIPFILE');
                 grunt.log.subhead('--- ' + command);
                 execRemote(command, options.debug, callback);


### PR DESCRIPTION
Fix following error:
>[D] STDERR: rm: 
>[D] STDERR: cannot remove ‘test/releases/20150320142407771/deploy.tgz’
>[D] STDERR: : No such file or directory
>[D] STDERR: 

>[D] REMOTE: cd test/releases/20150320142407771 && tar -xzvf deploy.tgz && rm test/releases/20150320142407771/deploy.tgz
