### PR TITLE
Change to releases directory before rm command. Fixes #26.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# grunt-ssh-deploy (Version: 0.2.6)
+# grunt-ssh-deploy (Version: 0.2.7)
 
 > SSH Deployment for Grunt using [ssh2](https://github.com/mscdex/ssh2).
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-ssh-deploy",
   "description": "Grunt SSH deployment",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "homepage": "https://github.com/dasuchin/grunt-ssh-deploy",
   "author": {
     "name": "Dustin Carlson",

--- a/tasks/ssh_deploy.js
+++ b/tasks/ssh_deploy.js
@@ -212,7 +212,7 @@ module.exports = function(grunt) {
                 if (typeof options.releases_to_keep === 'undefined') return callback();
                 if (options.releases_to_keep < 1) options.releases_to_keep = 1;
 
-                var command = "rm -rf `ls -r " + options.deploy_path + "/releases/ | awk 'NR>" + options.releases_to_keep + "'`";
+                var command = "cd " + options.deploy_path + "/releases/ && rm -rfv `ls -r " + options.deploy_path + "/releases/ | awk 'NR>" + options.releases_to_keep + "'`";
                 grunt.log.subhead('--------------- REMOVING OLD BUILDS');
                 grunt.log.subhead('--- ' + command);
                 execRemote(command, options.debug, callback);


### PR DESCRIPTION
releases_to_keep option was not working because the rm command was not always happening from the releases directory. Modified command to change to the proper directory first.