### PR TITLE
release_subdir option

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Type: `Number`
 
 The number of builds (including the current build) to keep in the remote releases directory. Must be >= 1.
 
-#### options.releases_subdir
+#### options.release_subdir
 Type: `String`
 Default value: `'/'`
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# grunt-ssh-deploy (Version: 0.2.8)
+# grunt-ssh-deploy (Version: 0.2.9)
 
 > SSH Deployment for Grunt using [ssh2](https://github.com/mscdex/ssh2).
 
@@ -80,7 +80,7 @@ Port to connect to on the remote server.
 #### options.deploy_path
 Type: `String`
 
-Full path on the remote server where files will be deployed. No trailing slash needed.
+Full path on the remote server where files will be deployed.
 
 #### options.local_path
 Type: `String`
@@ -102,6 +102,13 @@ Commands to run on the server before and after deploy directory is created and s
 Type: `Number`
 
 The number of builds (including the current build) to keep in the remote releases directory. Must be >= 1.
+
+#### options.releases_subdir
+Type: `String`
+Default value: `'/'`
+
+Name of the sub directory to store the release in. Useful when multiple projects get deployed
+to the same machine and the `releases_to_keep` option is being used.
 
 #### options.zip_deploy
 Type: `Boolean`
@@ -145,7 +152,8 @@ grunt.initConfig({
               username: '<%= secret.production.username %>',
               password: '<%= secret.production.password %>',
               port: '<%= secret.production.port %>',
-              releases_to_keep: '5'
+              releases_to_keep: '5',
+              releases_subdir: 'myapp'
           }
       }
   }

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ grunt.initConfig({
               password: '<%= secret.production.password %>',
               port: '<%= secret.production.port %>',
               releases_to_keep: '5',
-              releases_subdir: 'myapp'
+              release_subdir: 'myapp'
           }
       }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-ssh-deploy",
   "description": "Grunt SSH deployment",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "homepage": "https://github.com/dasuchin/grunt-ssh-deploy",
   "author": {
     "name": "Dustin Carlson",

--- a/tasks/ssh_deploy.js
+++ b/tasks/ssh_deploy.js
@@ -51,13 +51,13 @@ module.exports = function(grunt) {
             port: 22,
             zip_deploy: false,
             max_buffer: 200 * 1024,
-            releases_subdir: '/'
+            release_subdir: '/'
         };
 
         var options = extend({}, defaults, grunt.config.get('environments').options,
             grunt.config.get('environments')[this.args]['options']);
         
-        var releasePath = path.join(options.deploy_path, 'releases', options.releases_subdir, timestamp);
+        var releasePath = path.join(options.deploy_path, 'releases', options.release_subdir, timestamp);
 
         // scp defaults
         client.defaults(getScpOptions(options));
@@ -220,7 +220,7 @@ module.exports = function(grunt) {
                 if (typeof options.releases_to_keep === 'undefined') return callback();
                 if (options.releases_to_keep < 1) options.releases_to_keep = 1;
 
-                var command = "cd " + path.join(options.deploy_path, 'releases', options.releases_subdir) + " && rm -rfv `ls -r " + path.join(options.deploy_path, 'releases', options.releases_subdir) + " | awk 'NR>" + options.releases_to_keep + "'`";
+                var command = "cd " + path.join(options.deploy_path, 'releases', options.release_subdir) + " && rm -rfv `ls -r " + path.join(options.deploy_path, 'releases', options.release_subdir) + " | awk 'NR>" + options.releases_to_keep + "'`";
                 grunt.log.subhead('--------------- REMOVING OLD BUILDS');
                 grunt.log.subhead('--- ' + command);
                 execRemote(command, options.debug, callback);

--- a/tasks/ssh_deploy.js
+++ b/tasks/ssh_deploy.js
@@ -8,6 +8,8 @@
 
 'use strict';
 
+var path = require('path');
+
 var getScpOptions = function(options) {
     var scpOptions = {
         port: options.port,
@@ -43,12 +45,14 @@ module.exports = function(grunt) {
         var timestamp = moment().format('YYYYMMDDHHmmssSSS');
         var async = require('async');
         var extend = require('extend');
+        var releasePath = path.join(options.deploy_path, 'releases', options.releases_subdir, timestamp);
 
         var defaults = {
             current_symlink: 'current',
             port: 22,
             zip_deploy: false,
-            max_buffer: 200 * 1024
+            max_buffer: 200 * 1024,
+            releases_subdir: '/'
         };
 
         var options = extend({}, defaults, grunt.config.get('environments').options,
@@ -146,7 +150,7 @@ module.exports = function(grunt) {
             };
 
             var createReleases = function(callback) {
-                var command = 'cd ' + options.deploy_path + ' && mkdir -p releases/' + timestamp;
+                var command = 'mkdir -p ' + releasePath;
                 grunt.log.subhead('--------------- CREATING NEW RELEASE');
                 grunt.log.subhead('--- ' + command);
                 execRemote(command, options.debug, callback);
@@ -156,9 +160,9 @@ module.exports = function(grunt) {
                 var build = (options.zip_deploy) ? 'deploy.tgz' : options.local_path;
                 grunt.log.subhead('--------------- UPLOADING NEW BUILD');
                 grunt.log.debug('SCP FROM LOCAL: ' + build
-                    + '\n TO REMOTE: ' + options.deploy_path + '/releases/' + timestamp + '/');
+                    + '\n TO REMOTE: ' + releasePath);
                 client.scp(build, {
-                    path: options.deploy_path + '/releases/' + timestamp + '/'
+                    path: releasePath
                 }, function (err) {
                     if (err) {
                         grunt.log.errorlns(err);
@@ -171,9 +175,9 @@ module.exports = function(grunt) {
 
             var unzipOnRemote = function(callback) {
                 if (!options.zip_deploy) return callback();
-                var goToCurrent = "cd " + options.deploy_path + "/releases/" + timestamp;
+                var goToCurrent = "cd " + releasePath;
                 var untar = "tar -xzvf deploy.tgz";
-                var cleanup = "rm " + options.deploy_path + "/releases/" + timestamp + "/deploy.tgz";
+                var cleanup = "rm " + path.join(releasePath, "deploy.tgz");
                 var command = goToCurrent + " && " + untar + " && " + cleanup;
                 grunt.log.subhead('--------------- UNZIP ZIPFILE');
                 grunt.log.subhead('--- ' + command);
@@ -181,8 +185,8 @@ module.exports = function(grunt) {
             };
 
             var updateSymlink = function(callback) {
-                var delete_symlink = 'rm -rf ' + options.deploy_path + '/' + options.current_symlink;
-                var set_symlink = 'ln -s ' + options.deploy_path + '/releases/' + timestamp + ' ' + options.deploy_path + '/' + options.current_symlink;
+                var delete_symlink = 'rm -rf ' + path.join(options.deploy_path, options.current_symlink);
+                var set_symlink = 'ln -s ' + releasePath + ' ' + path.join(options.deploy_path, options.current_symlink);
                 var command = delete_symlink + ' && ' + set_symlink;
                 grunt.log.subhead('--------------- UPDATING SYM LINK');
                 grunt.log.subhead('--- ' + command);
@@ -190,7 +194,7 @@ module.exports = function(grunt) {
             };
 
             var deleteRelease = function(callback) {
-                var command = 'rm -rf ' + options.deploy_path + '/releases/' + timestamp + '/';
+                var command = 'rm -rf ' + releasePath;
                 grunt.log.subhead('--------------- DELETING RELEASE');
                 grunt.log.subhead('--- ' + command);
                 execRemote(command, options.debug, callback);
@@ -215,7 +219,7 @@ module.exports = function(grunt) {
                 if (typeof options.releases_to_keep === 'undefined') return callback();
                 if (options.releases_to_keep < 1) options.releases_to_keep = 1;
 
-                var command = "cd " + options.deploy_path + "/releases/ && rm -rfv `ls -r " + options.deploy_path + "/releases/ | awk 'NR>" + options.releases_to_keep + "'`";
+                var command = "cd " + path.join(options.deploy_path, 'releases') + " && rm -rfv `ls -r " + path.join(options.deploy_path, 'releases') + " | awk 'NR>" + options.releases_to_keep + "'`";
                 grunt.log.subhead('--------------- REMOVING OLD BUILDS');
                 grunt.log.subhead('--- ' + command);
                 execRemote(command, options.debug, callback);

--- a/tasks/ssh_deploy.js
+++ b/tasks/ssh_deploy.js
@@ -45,8 +45,7 @@ module.exports = function(grunt) {
         var timestamp = moment().format('YYYYMMDDHHmmssSSS');
         var async = require('async');
         var extend = require('extend');
-        var releasePath = path.join(options.deploy_path, 'releases', options.releases_subdir, timestamp);
-
+        
         var defaults = {
             current_symlink: 'current',
             port: 22,
@@ -57,6 +56,8 @@ module.exports = function(grunt) {
 
         var options = extend({}, defaults, grunt.config.get('environments').options,
             grunt.config.get('environments')[this.args]['options']);
+        
+        var releasePath = path.join(options.deploy_path, 'releases', options.releases_subdir, timestamp);
 
         // scp defaults
         client.defaults(getScpOptions(options));
@@ -219,7 +220,7 @@ module.exports = function(grunt) {
                 if (typeof options.releases_to_keep === 'undefined') return callback();
                 if (options.releases_to_keep < 1) options.releases_to_keep = 1;
 
-                var command = "cd " + path.join(options.deploy_path, 'releases') + " && rm -rfv `ls -r " + path.join(options.deploy_path, 'releases') + " | awk 'NR>" + options.releases_to_keep + "'`";
+                var command = "cd " + path.join(options.deploy_path, 'releases', options.releases_subdir) + " && rm -rfv `ls -r " + path.join(options.deploy_path, 'releases', options.releases_subdir) + " | awk 'NR>" + options.releases_to_keep + "'`";
                 grunt.log.subhead('--------------- REMOVING OLD BUILDS');
                 grunt.log.subhead('--- ' + command);
                 execRemote(command, options.debug, callback);

--- a/tasks/ssh_rollback.js
+++ b/tasks/ssh_rollback.js
@@ -76,16 +76,14 @@ module.exports = function(grunt) {
                 var command = delete_symlink + ' && ' + set_symlink;
                 grunt.log.subhead('--------------- UPDATING SYM LINK');
                 grunt.log.subhead('--- ' + command);
-                callback();
-                //execRemote(command, options.debug, callback);
+                execRemote(command, options.debug, callback);
             };
 
             var deleteRelease = function(callback) {
                 var command = 't=`ls -t1 ' + path.join(options.deploy_path, 'releases', options.release_subdir) + ' | sed -n 1p` && rm -rf ' + path.join(options.deploy_path, 'releases', options.release_subdir) + '$t/';
                 grunt.log.subhead('--------------- DELETING RELEASE');
                 grunt.log.subhead('--- ' + command);
-                callback();
-                //execRemote(command, options.debug, callback);
+                execRemote(command, options.debug, callback);
             };
 
             // closing connection to remote server


### PR DESCRIPTION
I was deploying two different applications to one machine and I was using `releases_to_keep` which was deleting old releases. I had been deploying the two apps at the same time regularly so I wasn't having any issues until I deployed only one of the apps a number of times in one day. This resulted in releases_to_keep deleting the current release folder for the other app - oops.

So I figured that the best way to solve this was to add a `release_subdir` so that app release folders are completely independent. By adding `release_subdir: 'myapp'` to your options the release folder changes from `releases/20150101120000` to  `releases/myapp/20150101120000`.

Now when I deploy an app, to the same machine as another app that used grunt-ssh-deploy,  the clean up won't affect the other app(s). 

I also changed the code to use `path.join` rather than having to worry about slashes.