### PR TITLE
Let user configure both release tag and relase root folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,13 @@ Type: `String`
 
 Commands to run on the server before and after deploy directory is created and symlinked. 
 
+#### options.tag
+Type: `String|function`
+Default value: the current date (as a timestamp)
+
+The release tag, e.g. '1.2.3'. It can be a string or a function (in that case is called and the returned value will be
+used). It defaults to the current timestamp formatted as 'YYYYMMDDHHmmssSSS'.
+
 #### options.releases_to_keep
 Type: `Number`
 
@@ -109,6 +116,13 @@ Default value: `'/'`
 
 Name of the sub directory to store the release in. Useful when multiple projects get deployed
 to the same machine and the `releases_to_keep` option is being used.
+
+#### options.release_root
+Type: `String`
+Default value: `'releases'`
+
+Name of the root directory where all the releases are published. If a `options.release_subdir` is also provided then
+the latest will be appended after this path.
 
 #### options.zip_deploy
 Type: `Boolean`

--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ Default value: the current date (as a timestamp)
 The release tag, e.g. '1.2.3'. It can be a string or a function (in that case is called and the returned value will be
 used). It defaults to the current timestamp formatted as 'YYYYMMDDHHmmssSSS'.
 
+*WARN*: release tag name **matters**. When used with parameter `releases_to_keep` the releases are reverse sorted
+alphabetically and older ones are removed. So be careful when you set your release tag name.
+
 #### options.releases_to_keep
 Type: `Number`
 

--- a/tasks/ssh_deploy.js
+++ b/tasks/ssh_deploy.js
@@ -51,13 +51,21 @@ module.exports = function(grunt) {
             port: 22,
             zip_deploy: false,
             max_buffer: 200 * 1024,
-            release_subdir: '/'
+            release_subdir: '/',
+            release_root: 'releases',
+            tag: timestamp
         };
 
         var options = extend({}, defaults, grunt.config.get('environments').options,
             grunt.config.get('environments')[this.args]['options']);
-        
-        var releasePath = path.posix.join(options.deploy_path, 'releases', options.release_subdir, timestamp);
+
+        var releaseTag = typeof options.tag == 'function' ? options.tag() : options.tag;
+        // Just a security check, avoiding empty tags that could mess up the file system
+        if (releaseTag == '') {
+            releaseTag = defaults.tag;
+        }
+
+        var releasePath = path.posix.join(options.deploy_path, options.release_root, options.release_subdir, releaseTag);
 
         // scp defaults
         client.defaults(getScpOptions(options));

--- a/tasks/ssh_deploy.js
+++ b/tasks/ssh_deploy.js
@@ -228,7 +228,7 @@ module.exports = function(grunt) {
                 if (typeof options.releases_to_keep === 'undefined') return callback();
                 if (options.releases_to_keep < 1) options.releases_to_keep = 1;
 
-                var command = "cd " + path.posix.join(options.deploy_path, 'releases', options.release_subdir) + " && rm -rfv `ls -r " + path.posix.join(options.deploy_path, 'releases', options.release_subdir) + " | awk 'NR>" + options.releases_to_keep + "'`";
+                var command = "cd " + path.posix.join(options.deploy_path, options.release_root, options.release_subdir) + " && rm -rfv `ls -r " + path.posix.join(options.deploy_path, options.release_root, options.release_subdir) + " | awk 'NR>" + options.releases_to_keep + "'`";
                 grunt.log.subhead('--------------- REMOVING OLD BUILDS');
                 grunt.log.subhead('--- ' + command);
                 execRemote(command, options.debug, callback);

--- a/tasks/ssh_rollback.js
+++ b/tasks/ssh_rollback.js
@@ -22,6 +22,7 @@ module.exports = function(grunt) {
             current_symlink: 'current',
             port: 22,
             max_buffer: 400 * 1024,
+            release_root: 'releases',
             release_subdir: '/'
         };
 
@@ -72,7 +73,7 @@ module.exports = function(grunt) {
 
             var updateSymlink = function(callback) {
                 var delete_symlink = 'rm -rf ' + path.posix.join(options.deploy_path, options.current_symlink);
-                var set_symlink = 'cd ' + options.deploy_path + ' && t=`ls -t1 ' + path.posix.join(options.deploy_path, 'releases', options.release_subdir) + ' | sed -n 2p` && ln -s ' + path.posix.join(options.deploy_path, 'releases', options.release_subdir) + '$t ' + options.current_symlink;
+                var set_symlink = 'cd ' + options.deploy_path + ' && t=`ls -t1 ' + path.posix.join(options.deploy_path, options.release_root, options.release_subdir) + ' | sed -n 2p` && ln -s ' + path.posix.join(options.deploy_path, options.release_root, options.release_subdir) + '$t ' + options.current_symlink;
                 var command = delete_symlink + ' && ' + set_symlink;
                 grunt.log.subhead('--------------- UPDATING SYM LINK');
                 grunt.log.subhead('--- ' + command);
@@ -80,7 +81,7 @@ module.exports = function(grunt) {
             };
 
             var deleteRelease = function(callback) {
-                var command = 't=`ls -t1 ' + path.posix.join(options.deploy_path, 'releases', options.release_subdir) + ' | sed -n 1p` && rm -rf ' + path.posix.join(options.deploy_path, 'releases', options.release_subdir) + '$t/';
+                var command = 't=`ls -t1 ' + path.posix.join(options.deploy_path, options.release_root, options.release_subdir) + ' | sed -n 1p` && rm -rf ' + path.posix.join(options.deploy_path, options.release_root, options.release_subdir) + '$t/';
                 grunt.log.subhead('--------------- DELETING RELEASE');
                 grunt.log.subhead('--- ' + command);
                 execRemote(command, options.debug, callback);


### PR DESCRIPTION
In some circumstances, you may need more flexibility on how the deployment folder is organized. I added a couple of more options:

- `tag` => let you tag a relase, so then you can have a more clean url like 'som/path/1.2.3/...'
- `release_root` => in such a way that you have flexibility on the folder name where your relase will be published.

In both cases I maintained the default to the values provided by the current implementation.