### PR TITLE
Force closing scp2 connection

### DIFF
--- a/tasks/ssh_deploy.js
+++ b/tasks/ssh_deploy.js
@@ -258,6 +258,10 @@ module.exports = function(grunt) {
             var closeConnection = function(callback) {
                 connection.end();
 
+                client.close();
+                client.__sftp = null;
+                client.__ssh = null;
+
                 callback();
             };
 


### PR DESCRIPTION
There's a bug in scp2 v0.1.4 that surfaces with infinite recursion when trying to deploy more than once in the same run. The already-closed underlying connection is reused and it fails. There's a fix in scp2 v0.2.0, but apparently there is something else wrong in that configuration - at least I'm getting "connection refused", so it's easier for me to fix it from here.

Fixes https://github.com/dasuchin/grunt-ssh-deploy/issues/45