### PR TITLE
Added support to specify the timeout for the ssh handshake

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# grunt-ssh-deploy (Version: 0.4.0)
+# grunt-ssh-deploy (Version: 0.4.1)
 
 > SSH Deployment for Grunt using [ssh2](https://github.com/mscdex/ssh2).
 
@@ -76,6 +76,12 @@ Type: `String`
 Default value: `'22'`
 
 Port to connect to on the remote server.
+
+#### options.readyTimeout
+Type: `Number`
+Default value: `20000`
+
+Default timeout (in milliseconds) to wait for the SSH handshake to complete.
 
 #### options.deploy_path
 Type: `String`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-ssh-deploy",
   "description": "Grunt SSH deployment",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "homepage": "https://github.com/dasuchin/grunt-ssh-deploy",
   "author": {
     "name": "Dustin Carlson",

--- a/tasks/ssh_deploy.js
+++ b/tasks/ssh_deploy.js
@@ -14,7 +14,8 @@ var getScpOptions = function(options) {
     var scpOptions = {
         port: options.port,
         host: options.host,
-        username: options.username
+        username: options.username,
+		readyTimeout: options.readyTimeout
     };
 
     if (options.privateKey) {
@@ -52,6 +53,7 @@ module.exports = function(grunt) {
             port: 22,
             zip_deploy: false,
             max_buffer: 200 * 1024,
+			readyTimeout: 20000,
             release_subdir: '/',
             release_root: 'releases',
             tag: timestamp,

--- a/tasks/ssh_deploy.js
+++ b/tasks/ssh_deploy.js
@@ -15,7 +15,7 @@ var getScpOptions = function(options) {
         port: options.port,
         host: options.host,
         username: options.username,
-		readyTimeout: options.readyTimeout
+        readyTimeout: options.readyTimeout
     };
 
     if (options.privateKey) {
@@ -53,7 +53,7 @@ module.exports = function(grunt) {
             port: 22,
             zip_deploy: false,
             max_buffer: 200 * 1024,
-			readyTimeout: 20000,
+            readyTimeout: 20000,
             release_subdir: '/',
             release_root: 'releases',
             tag: timestamp,


### PR DESCRIPTION
According to #31, I added the option `readyTimeout` to specify the timeout to wait for the SSH handshake to complete. This option will be passed through scp to the ssh2 module (https://www.npmjs.com/package/ssh2#client-methods).
